### PR TITLE
Implement `Position` for `[f32; 3]`

### DIFF
--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -34,6 +34,13 @@ pub trait Position {
     fn pos(&self) -> [f32; 3];
 }
 
+impl Position for [f32; 3] {
+    #[inline]
+    fn pos(&self) -> [f32; 3] {
+        *self
+    }
+}
+
 pub(crate) fn calc_pos_extents<Vertex>(vertices: &[Vertex]) -> ([f32; 3], f32)
 where
     Vertex: Position,


### PR DESCRIPTION
When already having data in a `Vec`, array or slice of `[f32; 3]` it is currently cumbersome to re-wrap that data in a newtype that implements `Position`, because crates cannot implement external (to them) traits on std types. Such re-wrapping typically involves careful transmuting or iterating and creating a copy of the source data, unnecessarily.